### PR TITLE
Update Chrome.ahk (changed 'ErrorDetails' to 'exceptionDetails')

### DIFF
--- a/Chrome.ahk
+++ b/Chrome.ahk
@@ -235,8 +235,8 @@ class Chrome {
 				awaitPromise: JSON.false
 			})
 			if (response is Map) {
-				if (response.Has('ErrorDetails'))
-					throw Error(response['result']['description'], , JSON.stringify(response['ErrorDetails']))
+				if (response.Has('exceptionDetails'))
+					throw Error(response['result']['description'], , JSON.stringify(response['exceptionDetails']))
 				return response['result']
 			}
 		}


### PR DESCRIPTION
per the documentation (https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-evaluate), the property name is (has recently become?) 'exceptionDetails':

Changing to `exceptionDetails` allows this code to properly throw (as expected) rather than return the result object (unexpected)
```
Chrome().GetPage().Evaluate("aksdlakd")
```