### PR TITLE
CGdip.ahk: FromScreen fixes

### DIFF
--- a/CGdip.ahk
+++ b/CGdip.ahk
@@ -2,8 +2,8 @@
  * @description Gdip类
  * @file CGdip.ahk
  * @author thqby
- * @date 2023/02/05
- * @version 1.0.8
+ * @date 2025/11/21
+ * @version 1.0.9
  ***********************************************************************/
 
 #Requires AutoHotkey v2.0-beta
@@ -429,17 +429,17 @@ class CGdip
 			return CGdip.Bitmap(pBitmap)
 		}
 
-		static FromScreen(Screen := 0, Raster := "") {
-			if (Screen = 0) {
-				x := SySGet(76)
-				y := SySGet(77)
-				w := SySGet(78)
-				h := SySGet(79)
+		static FromScreen(Screen := -1, Raster := "") {
+			if (Screen = -1) {
+				x := SysGet(76)
+				y := SysGet(77)
+				w := SysGet(78)
+				h := SysGet(79)
 			} else if (SubStr(Screen, 1, 5) = "hwnd:") {
 				Screen := SubStr(Screen, 6)
 				if !WinExist("ahk_id " Screen)
 					return -2
-				WinGetPos(, , &w, &h, "ahk_id" Screen)
+				WinGetPos(, , &w, &h, "ahk_id " Screen)
 				x := y := 0
 				hhdc := GetDCEx(Screen, 3)
 			} else if (Screen is Integer) {


### PR DESCRIPTION
SysGet 76, 77, 78, and 79 correlate to the virtual screen, which isn't the same as monitor 0. Without this change, while you can FromScreen a secondary monitor, you can't FromScreen the primary monitor without doing something like:

`Format("0|0|{}|{}", A_ScreenHeight, A_ScreenWidth)`

Now you can do `FromScreen(0)` just fine because I changed the default parameter value and if-check to `-1`

Unsure if the missing space after `ahk_id` on the `WinGetPos`'s line affects anything here, but it might.

Also corrected the casing of `SysGet` just because.